### PR TITLE
Modifie l'URL de taille maximale des avatars

### DIFF
--- a/Author.js
+++ b/Author.js
@@ -65,7 +65,8 @@ SK.Author.prototype.initFromCdv = function($cdv) {
         this.messageCount = parseInt($cdv.find("nb_messages").text()) || 0;
         this.avatar = $cdv.find("petite_image").text();
         this.fullSizeAvatar = $cdv.find("image").text();
-
+        this.fullSizeAvatar = this.fullSizeAvatar.replace(/\/(avatars?)-(sm|md)\//, "/$1/");
+        
         if(this.fullSizeAvatar === location.protocol + "//image.jeuxvideo.com/avatars/default.jpg") {
             this.fullSizeAvatar = this.avatar;
         }


### PR DESCRIPTION
Modifie l'attribut `fullSizeAvatar` pour qu'il contienne réellement l'avatar dans ses dimensions maximale.
Ce changement est utile lors de l'affichage des avatars dans une modale.

Chaque URL contient en effet des caractères indiquant les dimensions dans lesquelles l'afficher. Les supprimer permet d'obtenir l'avatar dans sa version d'origine, et donc de taille maximale.